### PR TITLE
Fix narrative permalinks and document GitHub Pages structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ agent_westworld/
     └── CLAUDE.md            # Claude-specific instructions
 ```
 
+## 🌐 GitHub Pages Mapping
+
+The repository is published to GitHub Pages with the following page mapping:
+
+| Repository File/Folder | Published URL |
+| ---------------------- | ------------- |
+| `index.md` | `/` |
+| `characters.md` | `/characters/` |
+| `scenes.md` | `/scenes/` |
+| `narratives.md` | `/narratives/` |
+| `narratives/<ID>.md` | `/narratives/<ID>/` |
+
+Static data such as files in `canon/` and `story/` are served at matching paths, allowing direct links from the site to the source data.
+
 ## 🤖 For AI Agents
 
 ### Triggering Work

--- a/narratives.md
+++ b/narratives.md
@@ -9,18 +9,16 @@ This page displays AI-generated narrative content for all scenes.
 
 ## Available Narratives
 
-- [S01E01-001](narratives/S01E01-001.html)
-- [S01E01-003](narratives/S01E01-003.html)
+- [S01E01-001](narratives/S01E01-001/)
+- [S01E01-003](narratives/S01E01-003/)
 
 ## Generation Script
-
 To generate narratives, run:
 ```bash
 python scripts/generate_site_content.py
 ```
 
 ## Raw Scene Data
-
 - [View All Scenes](story/scenes/)
 
 ---

--- a/narratives/index.md
+++ b/narratives/index.md
@@ -7,5 +7,5 @@ title: Narratives Index
 
 Browse all generated narrative content:
 
-- [S01E01-001](S01E01-001.html)
-- [S01E01-003](S01E01-003.html)
+- [S01E01-001](S01E01-001/)
+- [S01E01-003](S01E01-003/)

--- a/scripts/generate_site_content.py
+++ b/scripts/generate_site_content.py
@@ -114,7 +114,8 @@ def generate_narrative_index(narratives_dir):
 
             # Try to extract title from the narrative file
             title = narrative_file.stem.replace('_', ' ').title()
-            content.append(f"- [{title}](narratives/{narrative_file.stem}.html)")
+            # Use directory-style links to match Jekyll pretty permalinks
+            content.append(f"- [{title}](narratives/{narrative_file.stem}/)")
 
     content.extend([
         "",
@@ -133,7 +134,7 @@ def generate_narrative_index(narratives_dir):
     ])
 
     with open(output, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(content))
+        f.write('\n'.join(content) + '\n')
 
 def generate_narratives():
     """Main function to generate all narratives."""
@@ -212,10 +213,11 @@ def generate_narratives():
             continue
 
         scene_id = narrative_file.stem
-        index_content.append(f"- [{scene_id}]({scene_id}.html)")
+        # Link to directory to support pretty permalinks
+        index_content.append(f"- [{scene_id}]({scene_id}/)")
 
     with open(narratives_index, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(index_content))
+        f.write('\n'.join(index_content) + '\n')
 
     print("SUCCESS: Generated narratives index file")
 


### PR DESCRIPTION
## Summary
- Adjust narrative generation script to output directory-style links matching Jekyll permalinks
- Regenerate narrative index files with working links
- Document repository-to-site mapping in README

## Testing
- `python scripts/generate_site_content.py`
- `python checks/validate.py`
- `python checks/validate_markdown.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4eaff6ecc832a9bd87f3440e3f4c6